### PR TITLE
Fill the go.mod with current requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+env:
+  COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+on: push
+
+jobs:
+  test-framework:
+    name: Base testing
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Verify image builds
+        run: |
+          docker build --tag infrawatch/lokean:latest .
+
+      - name: List images
+        run: |
+          docker images

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module github.com/infrawatch/lokean
 
+
 go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/go-ini/ini v1.62.0
+	github.com/infrawatch/apputils v0.0.0-20201013121329-8439bdcd51ad
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/streadway/amqp v1.0.0
+	github.com/stretchr/testify v1.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+	qpid.apache.org v0.0.0-20190307183443-7bf92569070b
+)


### PR DESCRIPTION
This fill the go.mod file with current requirements. This should fix docker builds and it should allow successful builds on quay.io